### PR TITLE
feat: DIDComm lib A2A Client APIs

### DIFF
--- a/api/connection/connection.go
+++ b/api/connection/connection.go
@@ -1,7 +1,0 @@
-/*
-Copyright SecureKey Technologies Inc. All Rights Reserved.
-
-SPDX-License-Identifier: Apache-2.0
-*/
-
-package connection

--- a/api/connection/connection_test.go
+++ b/api/connection/connection_test.go
@@ -1,7 +1,0 @@
-/*
-Copyright SecureKey Technologies Inc. All Rights Reserved.
-
-SPDX-License-Identifier: Apache-2.0
-*/
-
-package connection

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module github.com/trustbloc/did-comm-go
+
+require github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -1,0 +1,96 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package connection
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	"github.com/trustbloc/did-comm-go/pkg/models/didexchange"
+	"github.com/trustbloc/did-comm-go/pkg/transport"
+)
+
+const (
+	connectionInvite   = "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/connections/1.0/invitation"
+	connectionRequest  = "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/connections/1.0/request"
+	connectionResponse = "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/connections/1.0/response"
+)
+
+// DIDComm supports DID communication apis
+type DIDComm struct {
+	transport transport.Transport
+}
+
+// NewDIDComm creates new instance of DID Communication
+func NewDIDComm(transport transport.Transport) *DIDComm {
+	return &DIDComm{transport: transport}
+}
+
+// SendInviteWithPublicDID sends the invite with public DID
+func (comm *DIDComm) SendInviteWithPublicDID(id, label, did string) error {
+	invitationJSON, err := json.Marshal(buildInvitationMessage(connectionInvite, id, label, did, nil, "", nil))
+	if err != nil {
+		panic(fmt.Sprintf("JSON Marshal Error : %s", err))
+	}
+
+	return comm.transport.Send(base64.URLEncoding.EncodeToString(invitationJSON))
+}
+
+// SendInviteWithKeyAndURLEndpoint sends the invite with recipient key and URL endpoint
+func (comm *DIDComm) SendInviteWithKeyAndURLEndpoint(id, label string, recipientKeys []string, serviceEndpoint string, routingKeys []string) error {
+	invitationJSON, err := json.Marshal(buildInvitationMessage(connectionInvite, id, label, "", recipientKeys, serviceEndpoint, routingKeys))
+	if err != nil {
+		panic(fmt.Sprintf("JSON Marshal Error : %s", err))
+	}
+
+	return comm.transport.Send(base64.URLEncoding.EncodeToString(invitationJSON))
+}
+
+// SendInviteWithKeyAndDIDServiceEndpoint sends the invite with recipient key and DID service endpoint
+func (comm *DIDComm) SendInviteWithKeyAndDIDServiceEndpoint(id, label string, recipientKeys []string, serviceEndpoint string, routingKeys []string) error {
+	invitationJSON, err := json.Marshal(buildInvitationMessage(connectionInvite, id, label, "", recipientKeys, serviceEndpoint, routingKeys))
+	if err != nil {
+		panic(fmt.Sprintf("JSON Marshal Error : %s", err))
+	}
+
+	return comm.transport.Send(base64.URLEncoding.EncodeToString(invitationJSON))
+}
+
+// SendExchangeRequest sends exchange request
+func (comm *DIDComm) SendExchangeRequest(exchangeRequest *didexchange.Request) error {
+	exchangeRequest.Type = connectionRequest
+	exchangeRequestJSON, err := json.Marshal(exchangeRequest)
+	if err != nil {
+		panic(fmt.Sprintf("JSON Marshal Error : %s", err))
+	}
+
+	return comm.transport.Send(string(exchangeRequestJSON))
+}
+
+// SendExchangeResponse sends exchange response
+func (comm *DIDComm) SendExchangeResponse(exchangeResponse *didexchange.Response) error {
+	exchangeResponse.Type = connectionResponse
+	exchangeResponseJSON, err := json.Marshal(exchangeResponse)
+	if err != nil {
+		panic(fmt.Sprintf("JSON Marshal Error : %s", err))
+	}
+
+	return comm.transport.Send(string(exchangeResponseJSON))
+}
+
+func buildInvitationMessage(messageType, id, label, did string, recipientKeys []string, serviceEndpoint string, routingKeys []string) *didexchange.InviteMessage {
+	return &didexchange.InviteMessage{
+		Type:            messageType,
+		ID:              id,
+		Label:           label,
+		DID:             did,
+		RecipientKeys:   recipientKeys,
+		ServiceEndpoint: serviceEndpoint,
+		RoutingKeys:     routingKeys,
+	}
+}

--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/did-comm-go/pkg/models/didexchange"
+	httptransport "github.com/trustbloc/did-comm-go/pkg/transport/http"
+)
+
+func TestSendInviteWithPublicDID(t *testing.T) {
+	didComm := NewDIDComm(httptransport.NewHTTPTransport())
+
+	require.NoError(t, didComm.SendInviteWithPublicDID(
+		"12345678900987654321",
+		"Alice",
+		"did:trustbloc:ZadolSRQkehfo",
+	))
+}
+
+func TestSendInviteWithKeyAndURLEndpoint(t *testing.T) {
+	didComm := NewDIDComm(httptransport.NewHTTPTransport())
+
+	require.NoError(t, didComm.SendInviteWithKeyAndURLEndpoint(
+		"12345678900987654321",
+		"Alice",
+		[]string{"8HH5gYEeNc3z7PYXmd54d4x6qAfCNrqQqEB3nS7Zfu7K"},
+		"https://example.com/endpoint",
+		[]string{"8HH5gYEeNc3z7PYXmd54d4x6qAfCNrqQqEB3nS7Zfu7K"}))
+}
+
+func TestSendInviteWithKeyAndDIDServiceEndpoint(t *testing.T) {
+	didComm := NewDIDComm(httptransport.NewHTTPTransport())
+
+	require.NoError(t, didComm.SendInviteWithKeyAndDIDServiceEndpoint(
+		"12345678900987654321",
+		"Alice",
+		[]string{"8HH5gYEeNc3z7PYXmd54d4x6qAfCNrqQqEB3nS7Zfu7K"},
+		"did:trustbloc:ZadolSRQkehfo;service=routeid",
+		[]string{"8HH5gYEeNc3z7PYXmd54d4x6qAfCNrqQqEB3nS7Zfu7K"}))
+}
+
+func TestSendRequest(t *testing.T) {
+	didComm := NewDIDComm(httptransport.NewHTTPTransport())
+
+	req := &didexchange.Request{
+		ID:    "5678876542345",
+		Label: "Bob",
+	}
+
+	require.NoError(t, didComm.SendExchangeRequest(req))
+}
+
+func TestSendResponse(t *testing.T) {
+	didComm := NewDIDComm(httptransport.NewHTTPTransport())
+
+	resp := &didexchange.Response{
+		ID: "12345678900987654321",
+		ConnectionSignature: &didexchange.ConnectionSignature{
+			Type: "did:trustbloc:RQkehfoFssiwQRuihskwoPSR;spec/ed25519Sha512_single/1.0/ed25519Sha512_single",
+		},
+	}
+
+	require.NoError(t, didComm.SendExchangeResponse(resp))
+}

--- a/pkg/models/didexchange/connection.go
+++ b/pkg/models/didexchange/connection.go
@@ -1,0 +1,58 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package didexchange
+
+// InviteMessage defines a2a invite message
+type InviteMessage struct {
+	Type            string   `json:"@type,omitempty"`
+	ID              string   `json:"@id,omitempty"`
+	Label           string   `json:"label,omitempty"`
+	DID             string   `json:"did,omitempty"`
+	RecipientKeys   []string `json:"recipientKeys,omitempty"`
+	ServiceEndpoint string   `json:"serviceEndpoint,omitempty"`
+	RoutingKeys     []string `json:"routingKeys,omitempty"`
+}
+
+// Request defines a2a exchange request
+type Request struct {
+	Type       string      `json:"@type,omitempty"`
+	ID         string      `json:"@id,omitempty"`
+	Label      string      `json:"label,omitempty"`
+	Connection *Connection `json:"connection,omitempty"`
+}
+
+// Response defines a2a exchange response
+type Response struct {
+	Type                string               `json:"@type,omitempty"`
+	ID                  string               `json:"@id,omitempty"`
+	ConnectionSignature *ConnectionSignature `json:"connection~sig,omitempty"`
+	Thread              *Thread              `json:"~thread,omitempty"`
+}
+
+// Thread thread data
+type Thread struct {
+	ID string `json:"@thid,omitempty"`
+}
+
+// ConnectionSignature connection signature
+type ConnectionSignature struct {
+	Type       string `json:"@type,omitempty"`
+	Signature  string `json:"signature,omitempty"`
+	SignedData string `json:"sig_data,omitempty"`
+	SignVerKey string `json:"signers,omitempty"`
+}
+
+// Connection connection
+type Connection struct {
+	DID    string  `json:"did,omitempty"`
+	DIDDoc *DIDDoc `json:"did_doc,omitempty"`
+}
+
+// DIDDoc did document
+// TODO can this be defined in did-common-go ?
+type DIDDoc struct {
+}

--- a/pkg/transport/http/http_transport.go
+++ b/pkg/transport/http/http_transport.go
@@ -1,0 +1,24 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package httptransport
+
+import (
+	"github.com/trustbloc/did-comm-go/pkg/transport"
+)
+
+// this is a WIP implementation of Transport protocol.
+type httpTransport struct {
+}
+
+// NewHTTPTransport provides a new HTTP transport
+func NewHTTPTransport() transport.Transport {
+	return &httpTransport{}
+}
+
+func (http *httpTransport) Send(data string) error {
+	return nil
+}

--- a/pkg/transport/transport_interface.go
+++ b/pkg/transport/transport_interface.go
@@ -1,0 +1,14 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package transport
+
+// Transport interface definition for transport layer
+// This is a WIP interface.
+type Transport interface {
+	// Send send a2a exchange data
+	Send(data string) error
+}


### PR DESCRIPTION
- Creat a new DIDComm type to instantiate the lib by passing the pluggable Transport type
- Define basic A2A client APIs
- Add type for Tranport with one function (Send) to get the structure in with HTTPTransport impl

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>