### PR TITLE
feat: Add ability to pass destination as a param to Exchange Request/Response Communication

### DIFF
--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -50,7 +50,7 @@ func GenerateInviteWithKeyAndEndpoint(inviteMessage *didexchange.InviteMessage) 
 }
 
 // SendExchangeRequest sends exchange request
-func (comm *DIDComm) SendExchangeRequest(exchangeRequest *didexchange.Request) error {
+func (comm *DIDComm) SendExchangeRequest(exchangeRequest *didexchange.Request, destination string) error {
 	if exchangeRequest == nil {
 		return errors.New("exchangeRequest cannot be nil")
 	}
@@ -60,11 +60,11 @@ func (comm *DIDComm) SendExchangeRequest(exchangeRequest *didexchange.Request) e
 		return errors.Wrapf(err, "Marshal Send Exchange Request Error")
 	}
 
-	return comm.transport.Send(string(exchangeRequestJSON), "https://localhost:8090") // same comment as above
+	return comm.transport.Send(string(exchangeRequestJSON), destination)
 }
 
 // SendExchangeResponse sends exchange response
-func (comm *DIDComm) SendExchangeResponse(exchangeResponse *didexchange.Response) error {
+func (comm *DIDComm) SendExchangeResponse(exchangeResponse *didexchange.Response, destination string) error {
 	if exchangeResponse == nil {
 		return errors.New("exchangeResponse cannot be nil")
 	}
@@ -74,7 +74,7 @@ func (comm *DIDComm) SendExchangeResponse(exchangeResponse *didexchange.Response
 		return errors.Wrapf(err, "Marshal Send Exchange Response Error")
 	}
 
-	return comm.transport.Send(string(exchangeResponseJSON), "https://localhost:8090") // same comment as above
+	return comm.transport.Send(string(exchangeResponseJSON), destination)
 }
 
 func encodedExchangeInvitation(inviteMessage *didexchange.InviteMessage) (string, error) {

--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -21,6 +21,7 @@ import (
 const certPrefix = "../transport/http/test/fixtures/certs/"
 const certPoolsPaths = certPrefix + "ec-pubCert1.pem," + certPrefix + "ec-pubCert2.pem," + certPrefix + "ec-pubCert3.pem,"
 const clientTimeout = 10 * time.Second
+const destinationURL = "https://localhost:8090"
 
 func TestGenerateInviteWithPublicDID(t *testing.T) {
 	invite, err := GenerateInviteWithPublicDID(&didexchange.InviteMessage{
@@ -98,8 +99,8 @@ func TestSendRequest(t *testing.T) {
 		Label: "Bob",
 	}
 
-	require.NoError(t, didComm.SendExchangeRequest(req))
-	require.Error(t, didComm.SendExchangeRequest(nil))
+	require.NoError(t, didComm.SendExchangeRequest(req, destinationURL))
+	require.Error(t, didComm.SendExchangeRequest(nil, destinationURL))
 }
 
 func TestSendResponse(t *testing.T) {
@@ -118,8 +119,8 @@ func TestSendResponse(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, didComm.SendExchangeResponse(resp))
-	require.Error(t, didComm.SendExchangeResponse(nil))
+	require.NoError(t, didComm.SendExchangeResponse(resp, destinationURL))
+	require.Error(t, didComm.SendExchangeResponse(nil, destinationURL))
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
Closes #10

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>