### PR TITLE
feat: Exchange Request/Response API - Remove receiver and add Transport to function args

### DIFF
--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -21,16 +21,6 @@ const (
 	connectionResponse = "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/connections/1.0/response"
 )
 
-// DIDComm supports DID communication apis
-type DIDComm struct {
-	transport transport.OutboundTransport
-}
-
-// NewDIDComm creates new instance of DID Communication
-func NewDIDComm(transport transport.OutboundTransport) *DIDComm {
-	return &DIDComm{transport: transport}
-}
-
 // GenerateInviteWithPublicDID generates the DID exchange invitation string with public DID
 func GenerateInviteWithPublicDID(inviteMessage *didexchange.InviteMessage) (string, error) {
 	if inviteMessage.ID == "" || inviteMessage.DID == "" {
@@ -50,7 +40,7 @@ func GenerateInviteWithKeyAndEndpoint(inviteMessage *didexchange.InviteMessage) 
 }
 
 // SendExchangeRequest sends exchange request
-func (comm *DIDComm) SendExchangeRequest(exchangeRequest *didexchange.Request, destination string) error {
+func SendExchangeRequest(exchangeRequest *didexchange.Request, destination string, transport transport.OutboundTransport) error {
 	if exchangeRequest == nil {
 		return errors.New("exchangeRequest cannot be nil")
 	}
@@ -60,11 +50,11 @@ func (comm *DIDComm) SendExchangeRequest(exchangeRequest *didexchange.Request, d
 		return errors.Wrapf(err, "Marshal Send Exchange Request Error")
 	}
 
-	return comm.transport.Send(string(exchangeRequestJSON), destination)
+	return transport.Send(string(exchangeRequestJSON), destination)
 }
 
 // SendExchangeResponse sends exchange response
-func (comm *DIDComm) SendExchangeResponse(exchangeResponse *didexchange.Response, destination string) error {
+func SendExchangeResponse(exchangeResponse *didexchange.Response, destination string, transport transport.OutboundTransport) error {
 	if exchangeResponse == nil {
 		return errors.New("exchangeResponse cannot be nil")
 	}
@@ -74,7 +64,7 @@ func (comm *DIDComm) SendExchangeResponse(exchangeResponse *didexchange.Response
 		return errors.Wrapf(err, "Marshal Send Exchange Response Error")
 	}
 
-	return comm.transport.Send(string(exchangeResponseJSON), destination)
+	return transport.Send(string(exchangeResponseJSON), destination)
 }
 
 func encodedExchangeInvitation(inviteMessage *didexchange.InviteMessage) (string, error) {

--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -92,15 +92,14 @@ func TestSendRequest(t *testing.T) {
 	}
 	oTr, err := httptransport.NewOutboundCommFromConfig(oCommConfig)
 	require.NoError(t, err)
-	didComm := NewDIDComm(oTr)
 
 	req := &didexchange.Request{
 		ID:    "5678876542345",
 		Label: "Bob",
 	}
 
-	require.NoError(t, didComm.SendExchangeRequest(req, destinationURL))
-	require.Error(t, didComm.SendExchangeRequest(nil, destinationURL))
+	require.NoError(t, SendExchangeRequest(req, destinationURL, oTr))
+	require.Error(t, SendExchangeRequest(nil, destinationURL, oTr))
 }
 
 func TestSendResponse(t *testing.T) {
@@ -110,7 +109,6 @@ func TestSendResponse(t *testing.T) {
 	}
 	oTr, err := httptransport.NewOutboundCommFromConfig(oCommConfig)
 	require.NoError(t, err)
-	didComm := NewDIDComm(oTr)
 
 	resp := &didexchange.Response{
 		ID: "12345678900987654321",
@@ -119,8 +117,8 @@ func TestSendResponse(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, didComm.SendExchangeResponse(resp, destinationURL))
-	require.Error(t, didComm.SendExchangeResponse(nil, destinationURL))
+	require.NoError(t, SendExchangeResponse(resp, destinationURL, oTr))
+	require.Error(t, SendExchangeResponse(nil, destinationURL, oTr))
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
Currently, the SendExchangeRequest and SendExchangeResponse are part of DIDComm receiver/member function. The functions use the receiver variable Transport, which is injected to the DIDComm receiver. Instead, transport can be passed as an argument to these functions. This way lib consumer don't have to maintain/use DIDComm instance to invoke these functions(plus will result in better readability).

Closes #20

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>