### PR TITLE
feat: Pass response data received from OutboundTransport

### DIFF
--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -50,7 +50,8 @@ func SendExchangeRequest(exchangeRequest *didexchange.Request, destination strin
 		return errors.Wrapf(err, "Marshal Send Exchange Request Error")
 	}
 
-	return transport.Send(string(exchangeRequestJSON), destination)
+	_, err = transport.Send(string(exchangeRequestJSON), destination)
+	return err
 }
 
 // SendExchangeResponse sends exchange response
@@ -64,7 +65,8 @@ func SendExchangeResponse(exchangeResponse *didexchange.Response, destination st
 		return errors.Wrapf(err, "Marshal Send Exchange Response Error")
 	}
 
-	return transport.Send(string(exchangeResponseJSON), destination)
+	_, err = transport.Send(string(exchangeResponseJSON), destination)
+	return err
 }
 
 func encodedExchangeInvitation(inviteMessage *didexchange.InviteMessage) (string, error) {

--- a/pkg/transport/http/http_transport_test.go
+++ b/pkg/transport/http/http_transport_test.go
@@ -28,6 +28,7 @@ type httpTestCase struct {
 	sendUrl      string
 	sendPayload  string
 	failSend     bool
+	respData     string
 }
 
 var testHandler http.Handler
@@ -46,6 +47,7 @@ func TestHTTPTransport(t *testing.T) {
 			url:          "/",
 			contentType:  "",
 			failHTTPPost: true,
+			respData:     "success",
 		},
 		{
 			name:         "Fail: Empty content type",
@@ -53,6 +55,7 @@ func TestHTTPTransport(t *testing.T) {
 			url:          "/",
 			contentType:  "",
 			failHTTPPost: true,
+			respData:     "success",
 		},
 		{
 			name:         "Fail: Empty HTTP method",
@@ -60,6 +63,7 @@ func TestHTTPTransport(t *testing.T) {
 			url:          "/",
 			contentType:  commContentType,
 			failHTTPPost: true,
+			respData:     "success",
 		},
 		{
 			name:         "Fail: bad url, content not found",
@@ -67,6 +71,7 @@ func TestHTTPTransport(t *testing.T) {
 			url:          "/badurl",
 			contentType:  commContentType,
 			failHTTPPost: true,
+			respData:     "success",
 		},
 		{
 			name:         "Pass - valid POST request",
@@ -77,6 +82,7 @@ func TestHTTPTransport(t *testing.T) {
 			sendUrl:      "https://localhost:8090",
 			sendPayload:  "test",
 			failSend:     false,
+			respData:     "success",
 		},
 		{
 			name:         "Send Fail - valid POST request but invalid Send call",
@@ -87,6 +93,7 @@ func TestHTTPTransport(t *testing.T) {
 			sendUrl:      "https://badurl",
 			sendPayload:  "test",
 			failSend:     true,
+			respData:     "success",
 		},
 		{
 			name:         "Send Fail - valid POST request and Send() URL but with bad payload",
@@ -97,6 +104,7 @@ func TestHTTPTransport(t *testing.T) {
 			sendUrl:      "https://localhost:8090",
 			sendPayload:  "bad",
 			failSend:     true,
+			respData:     "success",
 		},
 	}
 	for _, tc := range tcs {
@@ -112,12 +120,13 @@ func TestHTTPTransport(t *testing.T) {
 			if !tc.failHTTPPost {
 				require.Equal(t, http.StatusAccepted, rr.Code)
 
-				err = oCommHTTPClient.Send(tc.sendPayload, tc.sendUrl)
+				respData, err := oCommHTTPClient.Send(tc.sendPayload, tc.sendUrl)
 				if tc.failSend {
 					require.Error(t, err)
 					return
 				}
 				require.NoError(t, err)
+				require.Equal(t, tc.respData, respData)
 			}
 		})
 	}

--- a/pkg/transport/transport_interface.go
+++ b/pkg/transport/transport_interface.go
@@ -10,5 +10,5 @@ package transport
 // This is the client side of the agent
 type OutboundTransport interface {
 	// Send send a2a exchange data
-	Send(data string, destination string) error
+	Send(data string, destination string) (string, error)
 }


### PR DESCRIPTION
Update did-comm outbound transport send function to add a return param with response data. It should be up-to the higher abstractions to act on the response data and transport layer should just act as a pass through.

Closes #23 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>